### PR TITLE
Integrate newsletter subscription with freshmail API

### DIFF
--- a/src/FreshMail/Client.php
+++ b/src/FreshMail/Client.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace FreshMail\ApiV2;
 
@@ -15,116 +17,162 @@ use Psr\Log\LoggerInterface;
  */
 class Client
 {
-    const HOST   = 'api.freshmail.com';
-    const SCHEME = 'https';
-    const PREFIX = 'rest';
-    const VERSION = 'v2';
+  const HOST   = 'api.freshmail.com';
+  const SCHEME = 'https';
+  const PREFIX = 'rest';
+  const VERSION = 'v2';
 
-    const CLIENT_VERSION = '3.0';
+  const CLIENT_VERSION = '3.0';
 
-    /**
-     * Bearer Token for authorization
-     * @var string
-     */
-    private $bearerToken;
+  /**
+   * Error messages
+   * 
+   * @var array
+   */
+  private $messages = [
+    1301 => 'Adres email jest niepoprawny!',
+    1302 => 'Lista subskrypcyjna nie istnieje lub brak hash\'a listy!',
+    1303 => 'Jedno lub więcej pól dodatkowych jest niepoprawne!',
+    1304 => 'Subskrybent już istnieje w tej liście subskrypcyjnej!',
+    1305 => 'Próbowano nadać niepoprawny status subskrybenta!'
+  ];
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+  /**
+   * Bearer Token for authorization
+   * @var string
+   */
+  private $bearerToken;
 
-    /**
-     * @var \GuzzleHttp\Client
-     */
-    private $guzzle;
+  /**
+   * @var LoggerInterface
+   */
+  private $logger;
 
-    /**
-     * Client constructor.
-     * @param string $bearerToken
-     */
-    public function __construct($bearerToken = '')
-    {
-        $this->bearerToken = $bearerToken;
-        $this->logger = MonologFactory::createInstance();
-        $this->guzzle = new \GuzzleHttp\Client();
+  /**
+   * @var \GuzzleHttp\Client
+   */
+  private $guzzle;
+
+  /**
+   * Client constructor.
+   * @param string $bearerToken
+   */
+  public function __construct($bearerToken = '')
+  {
+    $this->bearerToken = $bearerToken;
+    $this->logger = MonologFactory::createInstance();
+    $this->guzzle = new \GuzzleHttp\Client();
+  }
+
+  /**
+   * @param $uri
+   * @param array $params
+   * @return array
+   * @throws Exception
+   */
+  public function doRequest(string $uri, array $params = [])
+  {
+    try {
+      $method = ($params) ? 'POST' : 'GET';
+
+      $response = $this->guzzle->request($method, $uri, $this->getRequestOptions($params));
+      $rawResponse = $response->getBody()->getContents();
+      $jsonResponse = json_decode($rawResponse, true);
+
+      if (!$jsonResponse) {
+        throw new ServerException(sprintf('Unable to parse response from server, raw response: %s', $rawResponse));
+      }
+
+      return $jsonResponse;
+    } catch (\GuzzleHttp\Exception\ClientException $exception) {
+      if ($exception->getCode() == 401) {
+        throw new UnauthorizedException('Request unauthorized');
+      }
+
+      $jsonError = $this->parseErrorMessage($exception->getMessage());
+
+      if (array_key_exists(intval($jsonError->errors[0]->code), $this->messages)) {
+        $errorMessage = $this->messages[intval($jsonError->errors[0]->code)];
+      } else {
+        $errorMessage = $jsonError->errors[0]->message;
+      }
+
+      throw new \FreshMail\ApiV2\ClientException($errorMessage, $jsonError->errors[0]->code);
+    } catch (\GuzzleHttp\Exception\ConnectException $exception) {
+      $jsonError = $this->parseErrorMessage($exception->getMessage());
+
+      if (array_key_exists(intval($jsonError->errors[0]->code), $this->messages)) {
+        $errorMessage = $this->messages[intval($jsonError->errors[0]->code)];
+      } else {
+        $errorMessage = $jsonError->errors[0]->message;
+      }
+
+      throw new ConnectionException($errorMessage, $jsonError->errors[0]->code);
     }
+  }
 
-    /**
-     * @param $uri
-     * @param array $params
-     * @return array
-     * @throws Exception
-     */
-    public function doRequest(string $uri, array $params = [])
-    {
-        try {
-            $method = ($params) ? 'POST' : 'GET';
+  /**
+   * @param LoggerInterface $logger
+   */
+  public function setLogger(LoggerInterface $logger)
+  {
+    $this->logger = $logger;
+  }
 
-            $response = $this->guzzle->request($method, $uri, $this->getRequestOptions($params));
-            $rawResponse = $response->getBody()->getContents();
-            $jsonResponse = json_decode($rawResponse, true);
+  /**
+   * @param \GuzzleHttp\Client $guzzle
+   */
+  public function setGuzzleHttpClient(\GuzzleHttp\Client $guzzle)
+  {
+    $this->guzzle = $guzzle;
+  }
 
-            if (!$jsonResponse) {
-                throw new ServerException(sprintf('Unable to parse response from server, raw response: %s', $rawResponse));
-            }
+  /**
+   * @return array
+   */
+  private function getRequestOptions(array $requestData): array
+  {
+    return [
+      'base_uri' => sprintf('%s://%s/%s/', self::SCHEME, self::HOST, self::PREFIX),
+      RequestOptions::BODY => json_encode($requestData),
+      RequestOptions::HEADERS => [
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'Authorization' => 'Bearer ' . $this->bearerToken,
+        'User-Agent' => $this->createUserAgent()
+      ]
+    ];
+  }
 
-            return $jsonResponse;
-        } catch (\GuzzleHttp\Exception\ClientException $exception) {
-            if ($exception->getCode() == 401) {
-                throw new UnauthorizedException('Request unauthorized');
-            }
+  /**
+   * @return string
+   */
+  private function createUserAgent(): string
+  {
+    return
+      sprintf(
+        'freshmail/php-api-v2-client:%s;guzzle:%s;php:%s;interface:%s',
+        self::VERSION,
+        self::CLIENT_VERSION,
+        PHP_VERSION,
+        php_sapi_name()
+      );
+  }
 
-            throw new \FreshMail\ApiV2\ClientException(sprintf('Connection error, error message: '.$exception->getMessage()));
-        } catch (\GuzzleHttp\Exception\ConnectException $exception) {
-            throw new ConnectionException(sprintf('Connection error, error message: '.$exception->getMessage()));
-        }
-    }
+  /**
+   * Undocumented function
+   *
+   * @param string $errorMessage
+   * @return \stdClass
+   */
+  private function parseErrorMessage($errorMessage): \stdClass
+  {
+    $arrayError = explode('{', $errorMessage);
+    unset($arrayError[0]);
+    $rawError = '{' . implode('{', $arrayError);
 
-    /**
-     * @param LoggerInterface $logger
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
-    }
+    $jsonError = json_decode($rawError);
 
-    /**
-     * @param \GuzzleHttp\Client $guzzle
-     */
-    public function setGuzzleHttpClient(\GuzzleHttp\Client $guzzle)
-    {
-        $this->guzzle = $guzzle;
-    }
-
-    /**
-     * @return array
-     */
-    private function getRequestOptions(array $requestData): array
-    {
-        return [
-            'base_uri' => sprintf('%s://%s/%s/', self::SCHEME, self::HOST, self::PREFIX),
-            RequestOptions::BODY => json_encode($requestData),
-            RequestOptions::HEADERS => [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'Authorization' => 'Bearer ' . $this->bearerToken,
-                'User-Agent' => $this->createUserAgent()
-            ]
-        ];
-    }
-
-    /**
-     * @return string
-     */
-    private function createUserAgent(): string
-    {
-        return
-            sprintf(
-                'freshmail/php-api-v2-client:%s;guzzle:%s;php:%s;interface:%s',
-                self::VERSION,
-                self::CLIENT_VERSION,
-                PHP_VERSION,
-                php_sapi_name()
-            );
-    }
+    return $jsonError;
+  }
 }


### PR DESCRIPTION
# Description
We want to use freshmail API to add new subscriber to the Career Map mailing list. To get proper PHP exceptions we have to change PHP library https://github.com/FreshMail/REST-API. We want to send email and name of the subscriber.

# Acceptance Criteria
 - Career Map contact form can add a new subscriber to Freshmail to Career Map mailing list
 - Career Map backend can send a proper array of messages to frontend
 - Career Map can send email and name of the subscriber to Freshmail